### PR TITLE
Add a contract deploy command to

### DIFF
--- a/scripts/test_contract
+++ b/scripts/test_contract
@@ -41,4 +41,9 @@ aut contract tx \
     --from ${ALICE} \
     approve ${BOB} 10_000_000_000_000_000_000
 
+# Alice deploys a dummy contract with 4 parameters
+aut contract deploy \
+    --contract ../tests/data/token_contract.json \
+    ${ALICE} 10000000000000000000 "Test Token" "TST"
+
 popd  # _test_contract_cli


### PR DESCRIPTION
This PR allows contracts to be deployed using the aut tool.
It can only be merged once autonity/autonity.py#21 in the submodule has been merged.
