### PR TITLE
Detect if an address is not a validator

### DIFF
--- a/aut/commands/account.py
+++ b/aut/commands/account.py
@@ -474,7 +474,6 @@ def verify_signature(
     message: str,
     signature_file: str,
 ) -> None:
-
     """
     Verify that the signature in SIGNATURE_FILE` is valid for the
     message MESSAGE, signed by the owner of the FROM address.

--- a/aut/commands/tx.py
+++ b/aut/commands/tx.py
@@ -118,7 +118,6 @@ def make(
     # use create_transaction and finalize_transaction wrappers.
 
     if token_addresss:
-
         if not from_addr:
             raise ClickException("from address not given")
 
@@ -139,7 +138,6 @@ def make(
         )
 
     else:
-
         if not from_addr:
             raise ClickException("from address not given")
 

--- a/aut/commands/validator.py
+++ b/aut/commands/validator.py
@@ -14,6 +14,8 @@ from aut.commands.protocol import protocol_group
 from click import group, command, option, argument, echo
 from typing import Optional
 
+import sys
+
 # Disable pylint warning about imports outside top-level.  We do this
 # intentionally to try and keep startup times of the CLI low.
 
@@ -55,7 +57,7 @@ def info(rpc_endpoint: Optional[str], validator_addr_str: str) -> None:
             f"The address {validator_addr_str} is not registered as a validator.",
             err=True,
         )
-        return
+        sys.exit(1)
     echo(to_json(aut.get_validator(validator_addr), pretty=True))
 
 

--- a/aut/commands/validator.py
+++ b/aut/commands/validator.py
@@ -52,9 +52,9 @@ def info(rpc_endpoint: Optional[str], validator_addr_str: str) -> None:
     validator_addr = get_validator_address(validator_addr_str)
     aut = autonity_from_endpoint_arg(rpc_endpoint)
     validator_data = aut.get_validator(validator_addr)
-    if validator_data is None or validator_data.get("addr", "") != validator_addr_str:
+    if validator_data is None or validator_data.get("addr", "") != validator_addr:
         echo(
-            f"The address {validator_addr_str} is not registered as a validator.",
+            f"The address {validator_addr} is not registered as a validator.",
             err=True,
         )
         sys.exit(1)

--- a/aut/commands/validator.py
+++ b/aut/commands/validator.py
@@ -2,6 +2,7 @@
 The `validator` command group.
 """
 
+from aut.constants import UnixExitStatus
 from aut.options import (
     rpc_endpoint_option,
     keyfile_option,
@@ -57,7 +58,7 @@ def info(rpc_endpoint: Optional[str], validator_addr_str: str) -> None:
             f"The address {validator_addr} is not registered as a validator.",
             err=True,
         )
-        sys.exit(1)
+        sys.exit(UnixExitStatus.WEB3_RESOURCE_NOT_FOUND)
     echo(to_json(aut.get_validator(validator_addr), pretty=True))
 
 

--- a/aut/commands/validator.py
+++ b/aut/commands/validator.py
@@ -11,7 +11,7 @@ from aut.options import (
 )
 from aut.commands.protocol import protocol_group
 
-from click import group, command, option, argument
+from click import group, command, option, argument, echo
 from typing import Optional
 
 # Disable pylint warning about imports outside top-level.  We do this
@@ -49,7 +49,14 @@ def info(rpc_endpoint: Optional[str], validator_addr_str: str) -> None:
 
     validator_addr = get_validator_address(validator_addr_str)
     aut = autonity_from_endpoint_arg(rpc_endpoint)
-    print(to_json(aut.get_validator(validator_addr), pretty=True))
+    validator_data = aut.get_validator(validator_addr)
+    if validator_data is None or validator_data.get("addr", "") != validator_addr_str:
+        echo(
+            f"The address {validator_addr_str} is not registered as a validator.",
+            err=True,
+        )
+        return
+    echo(to_json(aut.get_validator(validator_addr), pretty=True))
 
 
 validator.add_command(info)


### PR DESCRIPTION
When there is a request to get the info of a validator by address, check that the response identify a validator, otherwise print an error.

How to smoke test:

For a validator
```console
aut  validator info --validator 0x32F3493Ef14c28419a98Ff20dE8A033cf9e6aB97
```

should print 

```json
{
  "treasury": "0x75474aC55768fAb6fE092191eea8016b955072F5",
  "addr": "0x32F3493Ef14c28419a98Ff20dE8A033cf9e6aB97",
  "enode": "enode://d4dc137f987e17155a69b31e566494c16edafd228912483cc519a48ce85864781faccc38141cc0eb1df8cdb28b9b3ccd10e1c298bac78ac43bbe5804021c1152@34.142.71.5:30303",
  "commission_rate": 1000,
  "bonded_stake": 10000000000000000000000,
  "total_slashed": 0,
  "liquid_contract": "0xf4D9599aFd90B5038b18e3B551Bc21a97ed21c37",
  "liquid_supply": 10000000000000000000000,
  "registration_block": 0,
  "state": 0
}
```

For an address that is not a validator
```
aut validator info --validator 0xe2Fb069045dFB19f3DD2B95A5A09D6F62984932d
```

should print

```
The address 0xe2Fb069045dFB19f3DD2B95A5A09D6F62984932d is not registered as a validator.
```


gh-113