### PR TITLE
Prepare release v0.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,9 @@
 - Add subcommand `aut protocol contract-src` to print the URL to the source of the Autonity contract used to generate the bundled ABI
 - Add subcommand `aut protocol contract-version` to print the git commit of the Autonity contract used to generate the bundled ABI
 - Add subcommand `aut protocol contract-address` to print the address of the Autonity contract 
-- Add support for python 3.11 (gh-107)
-- Improve messaging when querying validator info for an address that is not in the validator committee (gh-113)
-- Add support for complex types in contract calls (gh-120)
+- Add support for python 3.11 ([gh-107](https://github.com/autonity/aut/issues/107))
+- Improve messaging when querying validator info for an address that is not in the validator committee ([gh-113](https://github.com/autonity/aut/issues/113))
+- Add support for complex types in contract calls ([gh-120](https://github.com/autonity/aut/issues/120))
 
 ### Docs
 
@@ -15,7 +15,7 @@
 
 ### Chore
 
-- Use hatch as python tool to manage builds  (gh-116)
+- Use hatch as python tool to manage builds  ([gh-116](https://github.com/autonity/aut/issues/116))
 - Update dependency to autonity.py v1.0.0
 
 ### BREAKING CHANGES

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,27 @@
+# v0.2.0
+
+- Add subcommand `aut protocol contract-abi-path` to print the path of the bundled ABI for the Autonity contract
+- Add subcommand `aut protocol contract-src` to print the URL to the source of the Autonity contract used to generate the bundled ABI
+- Add subcommand `aut protocol contract-version` to print the git commit of the Autonity contract used to generate the bundled ABI
+- Add subcommand `aut protocol contract-address` to print the address of the Autonity contract 
+- Add support for python 3.11 (gh-107)
+- Improve messaging when querying validator info for an address that is not in the validator committee (gh-113)
+- Add support for complex types in contract calls (gh-120)
+
+### Docs
+
+- Add examples how to execute contract calls 
+- Update the development explanation for contributors
+
+### Chore
+
+- Use hatch as python tool to manage builds  (gh-116)
+- Update dependency to autonity.py v1.0.0
+
+### BREAKING CHANGES
+
+- Remove DEFAULT_CHAIN_ID constants
+
 # v0.1.4
 
 - Added `contract deploy` command

--- a/aut/__version__.py
+++ b/aut/__version__.py
@@ -2,4 +2,4 @@
 Module version information.
 """
 
-__version__ = "0.1.5.dev1"
+__version__ = "0.2.0"

--- a/aut/constants.py
+++ b/aut/constants.py
@@ -6,7 +6,6 @@ Constants
 class Defaults:
     """Default configuration variables."""
 
-    DEFAULT_CHAIN_ID = 65010000  # bakerloo
     DEFAULT_RPC_ENDPOINT = "http://localhost:8545"
 
 

--- a/aut/user.py
+++ b/aut/user.py
@@ -72,11 +72,6 @@ def get_account_stats(
 
 # TODO: Properly typed object.
 # TODO: Move to autonity.py
-
-
-# TODO: Move to autonity.py
-
-
 def get_block(w3: Web3, identifier: BlockIdentifier) -> BlockData:
     """
     Returns a dictionary of block data for the block identified by
@@ -88,8 +83,6 @@ def get_block(w3: Web3, identifier: BlockIdentifier) -> BlockData:
 
 
 # TODO: support this?
-
-
 def server_signtx(tx: TxParams) -> SignedTx:
     """
     Sign the transaction data contained in dictionary 'tx' by

--- a/aut/utils.py
+++ b/aut/utils.py
@@ -66,7 +66,6 @@ def web3_from_endpoint_arg(w3: Optional[Web3], endpoint_arg: Optional[str]) -> W
     if w3 is None:
         # TODO: For now, ignore the chain ID by default.  Later, this
         # check should be enabled and controllable by a flag.
-
         return create_web3_for_endpoint(
             config.get_rpc_endpoint(endpoint_arg), ignore_chain_id=True
         )


### PR DESCRIPTION
Bump version and update the  changelog

! technically introduces a breaking change that is removing the unused constant `DEFAULT_CHAIN_ID` !