### PR TITLE
Remove top-level Web3 imports to speed up loading time

### DIFF
--- a/aut/commands/account.py
+++ b/aut/commands/account.py
@@ -2,10 +2,9 @@
 The `account` command group.
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 from click import ClickException, Path, argument, command, group, option
-from web3.types import BlockIdentifier
 
 from aut.options import (
     from_option,
@@ -65,7 +64,7 @@ def info(
     rpc_endpoint: Optional[str],
     keyfile: Optional[str],
     accounts: List[str],
-    asof: Optional[BlockIdentifier],
+    asof: Optional[str],
 ) -> None:
     """
     Print some information about the given account (falling back to
@@ -73,6 +72,7 @@ def info(
     """
 
     from web3 import Web3
+    from web3.types import BlockIdentifier
 
     from aut.user import get_account_stats
     from aut.utils import (
@@ -88,9 +88,10 @@ def info(
         accounts = [account]
 
     addresses = [Web3.to_checksum_address(act) for act in accounts]
+    block = cast(BlockIdentifier, asof) if asof is not None else None
 
     w3 = web3_from_endpoint_arg(None, rpc_endpoint)
-    account_stats = get_account_stats(w3, addresses, asof)
+    account_stats = get_account_stats(w3, addresses, block)
     print(to_json(account_stats, pretty=True))
 
 

--- a/aut/commands/validator.py
+++ b/aut/commands/validator.py
@@ -3,9 +3,8 @@ The `validator` command group.
 """
 
 import sys
-from typing import Optional
+from typing import Optional, cast
 
-from autonity.validator import OracleAddress
 from click import argument, command, echo, group, option
 
 from aut.commands.protocol import protocol_group
@@ -224,7 +223,7 @@ def register(
     nonce: Optional[int],
     chain_id: Optional[int],
     enode: str,
-    oracle: OracleAddress,
+    oracle: str,
     consensus_key: str,
     proof: str,
 ) -> None:
@@ -233,6 +232,7 @@ def register(
     """
     from web3.types import HexBytes
 
+    from autonity.validator import OracleAddress
     from aut.utils import (
         autonity_from_endpoint_arg,
         create_contract_tx_from_args,
@@ -246,10 +246,12 @@ def register(
     from_addr = from_address_from_argument(from_str, keyfile)
     # TODO: validate enode string?
 
+    oracle_addr = cast(OracleAddress, oracle)
+
     aut = autonity_from_endpoint_arg(rpc_endpoint)
     tx = create_contract_tx_from_args(
         function=aut.register_validator(
-            enode, oracle, consensus_key_bytes, proof_bytes
+            enode, oracle_addr, consensus_key_bytes, proof_bytes
         ),
         from_addr=from_addr,
         gas=gas,


### PR DESCRIPTION
Commit https://github.com/autonity/aut/commit/cc5e605e65c8c1a657075b913fa0b42d0b6f383a moved all imports of Autonity.py and Web3.py from
top-level into functions in order to speed up loading time of the `aut`
command for printing help messages.

Profiling result with pyinstrument: [1]
```
0.411 <module>  aut/__main__.py:1
├─ 0.393 <module>  aut/commands/account.py:1
│  └─ 0.392 <module>  web3/__init__.py:1
│        [99 frames hidden]  web3, ens, pyunormalize, <built-in>, ...
└─ 0.006 <module>  click/__init__.py:1
      [2 frames hidden]  click
```
shows that importing Web3.py takes almost ~400 ms; if we don't import
Web3.py unless a command that requires it runs, the execution time of
of any `aut --help` command is greatly reduced.

However later commits https://github.com/autonity/aut/commit/517efd086e21850e93abfdd30f6975038ddcb35c and https://github.com/autonity/aut/commit/b7cf048e03a684d7129396bd649898cba6b77151 re-added Autonity.py and
Web3.py imports to the top-level for typing purposes. As a result
Web3.py is again imported for any `aut` command, therefore there is no
reduction in loading times.

This commit removes these top-level imports.

Note that Click recommends 2 methods for lazy loading external
libraries: one is moving imports into command functions [2] as currently
used; the other one is creating a "Lazy Group" subclass of `click.Group`
[3] that loads commands on demand. The latter results in a neater
codebase, however dynamic imports with `imporlib` seem to add ~150 ms to
the execution time of any command, therefore it is not a good option.

[1]: https://github.com/joerick/pyinstrument
[2]: https://click.palletsprojects.com/en/8.1.x/complex/#further-deferring-imports
[3]: https://click.palletsprojects.com/en/8.1.x/complex/#lazily-loading-subcommands