### PR TITLE
Resolve clashing `-f` short options for `aut account verify-signature`

### DIFF
--- a/aut/commands/account.py
+++ b/aut/commands/account.py
@@ -404,7 +404,7 @@ account_group.add_command(sign_message)
 @from_option
 @option(
     "--use-message-file",
-    "-f",
+    "-m",
     is_flag=True,
     help="Interpret MESSAGE as a filename where - means stdin",
 )


### PR DESCRIPTION
The `aut account verify-signature` command has 2 options with `-f` as short option. Change the short option of `--use-message-file` from `-f` to `-m`, and keep `-f` for `--from` as also used with other commands.

Resolves #170.